### PR TITLE
Multi items queries

### DIFF
--- a/src/YahooWeatherAPI.php
+++ b/src/YahooWeatherAPI.php
@@ -101,7 +101,7 @@ class YahooWeatherAPI implements YahooWeatherAPIInterface
             );
             $response = $this->client->request('GET', $this->yql, $headers);
             $response = json_decode($response->getBody(), true);
-            if (!isset($response['query']['results']['channel']['item']['condition'])) {
+            if (!isset($response['query']['results']['channel'])) {
                 $this->lastResponse = false;
             } else {
                 $this->lastResponse = $response['query']['results']['channel'];


### PR DESCRIPTION
Multi Items result have several items, so this is condition don't be true, but we have results. Try this query for example
https://query.yahooapis.com/v1/public/yql?format=json&q=select+location.city%2C+location.region%2C+wind.speed%2C+atmosphere.humidity%2C+item.condition.temp%2C+item.condition.text+from+weather.forecast+where+woeid+in+%28select+woeid+from+geo.places%281%29+where+text+in+%28%22Denver%2C+CO%22%2C+%22Nashville%2C+TN%22%2C+%22Boston%2C+MA%22%2C+%22Atlanta%2C+GA%22%29%29